### PR TITLE
Change speech at COSCUP to the correct year

### DIFF
--- a/en/about/index.html
+++ b/en/about/index.html
@@ -445,7 +445,7 @@
                     <ul>
                         <li>
                             <a href="https://coscup.org/"
-                                >COSCUP 2025 - The Path to Freedom: The Open
+                                >COSCUP 2024 - The Path to Freedom: The Open
                                 Source Journey of SCAICT</a
                             >
                         </li>

--- a/zh-Hant/about/index.html
+++ b/zh-Hant/about/index.html
@@ -452,7 +452,7 @@
                     <ul>
                         <li>
                             <a href="https://coscup.org/"
-                                >COSCUP 2025 - 前往自由的路上:
+                                >COSCUP 2024 - 前往自由的路上:
                                 中電喵的開源之旅</a
                             >
                         </li>


### PR DESCRIPTION
《前往自由的路上 - 中電喵的開源之旅》是 [COSCUP 2024 的議程](https://coscup.org/2024/zh-TW/session/KZ9VBD)，所以我把 2025 改成 2024 了。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the COSCUP event link on the About pages so that it now displays 2024 instead of 2025.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->